### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,4 +1,6 @@
 name: Python package
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/gilfree/pytest-isolate/security/code-scanning/1](https://github.com/gilfree/pytest-isolate/security/code-scanning/1)

The best way to fix the problem is to add an explicit `permissions` block in the workflow. The most minimal and recommended approach is to add this block at the top level (immediately below `name:` and above `on:`), which will apply it to all jobs by default. The minimal permission generally appropriate for most workflows is `contents: read`, which only allows reading repository contents (source code), and blocks accidental modification. If a job requires additional write permissions, these can be overridden at the job level, but in this case, the workflow only installs dependencies and runs tests, so `contents: read` is sufficient.

**What to change:**  
- In `.github/workflows/python-package.yml`, insert the following lines after `name: Python package` and before `on:`:

```yaml
permissions:
  contents: read
```
- No additional imports or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
